### PR TITLE
Adapt to handle newer mlpack API.

### DIFF
--- a/R/bandwidth.R
+++ b/R/bandwidth.R
@@ -44,7 +44,11 @@ find_tda_bw <- function(X, fast = TRUE, gamma = 0.98, use_differences = FALSE) {
   # }
 
   # Code above replaced with much faster mlpack computation, which produces identical output
-  phom <- mlpack::emst(X)$output
+  if (packageVersion(mlpack) < "4.8.0") {
+    phom <- mlpack::emst(X)$output
+  } else {
+    phom <- mlpack::emst(X)
+  }
   death_radi <- phom[, 3L]
 
   # Added so that very small death radi are not chosen

--- a/R/bandwidth.R
+++ b/R/bandwidth.R
@@ -44,7 +44,7 @@ find_tda_bw <- function(X, fast = TRUE, gamma = 0.98, use_differences = FALSE) {
   # }
 
   # Code above replaced with much faster mlpack computation, which produces identical output
-  if (packageVersion(mlpack) < "4.8.0") {
+  if (packageVersion("mlpack") < "4.8.0") {
     phom <- mlpack::emst(X)$output
   } else {
     phom <- mlpack::emst(X)

--- a/R/outlier_persistence.R
+++ b/R/outlier_persistence.R
@@ -71,7 +71,7 @@ persisting_outliers <- function(
   # }
 
   # Code above replaced with much faster mlpack computation, which produces identical output
-  if (packageVersion(mlpack) < "4.8.0") {
+  if (packageVersion("mlpack") < "4.8.0") {
     phom <- mlpack::emst(X)$output
   } else {
     phom <- mlpack::emst(X)

--- a/R/outlier_persistence.R
+++ b/R/outlier_persistence.R
@@ -71,7 +71,11 @@ persisting_outliers <- function(
   # }
 
   # Code above replaced with much faster mlpack computation, which produces identical output
-  phom <- mlpack::emst(X)$output
+  if (packageVersion(mlpack) < "4.8.0") {
+    phom <- mlpack::emst(X)$output
+  } else {
+    phom <- mlpack::emst(X)
+  }
 
   # Find bandwiths
   death_radi <- phom[, 3L]


### PR DESCRIPTION
Hi there,

I'm glad you found mlpack useful in your work here. We just did a release for version 4.8.0 and due to a little bit of an oversight, the API for mlpack::emst ended up changing (normally we try to keep API-changing releases as major release bumps). I would say it's for the better: instead of awkwardly returning a one-element list, it now returns just the output matrix itself.

Anyway, this diff allows compatibility with both old and new versions.  Note that I *did not test this*, but it *should* work.  You should definitely test it on your end.

If you prefer, you could just remove the $output instead and we can submit updated versions of both lookout and mlpack 4.8.0 to CRAN at the same time; let me know what you think.

Thanks so much!